### PR TITLE
Task/task91 httpclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,50 @@ Client supports multiple input types:
 * byte[] fileAsByteArray, String filename
 * String fileAsBase64String, String filename
 
+### HttpClient Customizations
+Mindee's API lives on the internet and many internal applications on corporate networks may therefore need to configure an HTTP proxy to access it. This is possble by using a `MindeeClient` configured to use a user provided instance  of the `com.mindee.parsing.MindeeApi` interface. There are a few layers to this:
+
+* The default implementation of `com.mindee.parsing.MindeeApi` interface is `com.mindee.http.MindeeHttpApi` 
+* `MindeeHttpApi` can be initialized with an Apache HttpComponents `HttpClientBuilder`.
+* `HttpClientBuilder` can be configured for use cases like proxying requests, custom authentication schemes, setting SSL Context etc.
+
+To Configure a `MindeeClient` to use a proxy, the following code can be referenced.
+```java
+import org.apache.http.HttpHost;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import com.mindee.parsing;
+import com.mindee.parsing.invoice;
+import com.mindee.MindeeClient;
+import com.mindee.MindeeClientInit;
+import com.mindee.DocumentToParse;
+import com.mindee.MindeeSettings;
+import com.mindee.http.MindeeHttpApi;
+import com.mindee.parsing.common.Document;
+import com.mindee.parsing.invoice.InvoiceV4Inference;
+
+// you can also configure things like caching, custom HTTPS certs,
+// timeouts and connection pool sizes here.
+// See: https://hc.apache.org/httpcomponents-client-5.1.x/current/httpclient5/apidocs/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.html
+HttpHost proxy = new HttpHost("<proxy-host>", <proxy-port>);
+DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
+HttpClientBuilder httpclientBuilder = HttpClients.custom().setRoutePlanner(routePlanner);
+
+// Build MindeeHttpAPI using the HtppClientBuilder
+MindeeHttpApi mindeeHttpApi =  MindeeHttpApi.builder()
+       .mindeeSettings(new MindeeSettings("<my-api-key>"))
+       .httpClientBuilder(httpclientBuilder)
+       .build();
+
+MindeeClient mindeeClient = MindeeClientInit.create(mindeeHttpApi);
+Document<InvoiceV4Inference> invoiceDocument = mindeeClient.parse(
+    InvoiceV4Inference.class,
+    documentToParse
+    );
+
+```
+
 ## Further Reading
 Complete details on the working of the library are available in the following guides:
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <groupId>com.mindee.sdk</groupId>
   <artifactId>mindee-api-java</artifactId>
@@ -310,6 +310,12 @@
       <scope>test</scope>
       <version>4.6.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>${wiremock.version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 
@@ -325,9 +331,11 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <org.mapstruct.version>1.5.3.Final</org.mapstruct.version>
-    <org.projectlombok.lombok-mapstruct-binding.version>0.2.0</org.projectlombok.lombok-mapstruct-binding.version>
+    <org.projectlombok.lombok-mapstruct-binding.version>0.2.0
+    </org.projectlombok.lombok-mapstruct-binding.version>
     <org.projectlombok.version>1.18.26</org.projectlombok.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <wiremock.version>2.27.2</wiremock.version>
   </properties>
 
 </project>

--- a/src/main/java/com/mindee/MindeeClientInit.java
+++ b/src/main/java/com/mindee/MindeeClientInit.java
@@ -17,8 +17,8 @@ public class MindeeClientInit {
    */
   public static MindeeClient create() {
     return new MindeeClient(
-      new PdfBoxApi(),
-      createDefault("")
+        new PdfBoxApi(),
+        createDefault("")
     );
   }
 
@@ -30,8 +30,8 @@ public class MindeeClientInit {
   public static MindeeClient create(String apiKey) {
 
     return new MindeeClient(
-      new PdfBoxApi(),
-      createDefault(apiKey)
+        new PdfBoxApi(),
+        createDefault(apiKey)
     );
   }
 
@@ -44,8 +44,8 @@ public class MindeeClientInit {
   public static MindeeClient create(MindeeApi mindeeApi) {
 
     return new MindeeClient(
-      new PdfBoxApi(),
-      mindeeApi
+        new PdfBoxApi(),
+        mindeeApi
     );
   }
 
@@ -64,7 +64,7 @@ public class MindeeClientInit {
     }
 
     return MindeeHttpApi.builder()
-      .mindeeSettings(mindeeSettings)
-      .build();
+        .mindeeSettings(mindeeSettings)
+        .build();
   }
 }

--- a/src/main/java/com/mindee/MindeeClientInit.java
+++ b/src/main/java/com/mindee/MindeeClientInit.java
@@ -17,8 +17,8 @@ public class MindeeClientInit {
    */
   public static MindeeClient create() {
     return new MindeeClient(
-        new PdfBoxApi(),
-        createDefault("")
+      new PdfBoxApi(),
+      createDefault("")
     );
   }
 
@@ -30,8 +30,22 @@ public class MindeeClientInit {
   public static MindeeClient create(String apiKey) {
 
     return new MindeeClient(
-        new PdfBoxApi(),
-        createDefault(apiKey)
+      new PdfBoxApi(),
+      createDefault(apiKey)
+    );
+  }
+
+
+  /**
+   * Create a MindeeClient using a MindeeApi.
+   *
+   * @param mindeeApi The MindeeApi implementation to be used by the created MindeeClient.
+   */
+  public static MindeeClient create(MindeeApi mindeeApi) {
+
+    return new MindeeClient(
+      new PdfBoxApi(),
+      mindeeApi
     );
   }
 
@@ -49,6 +63,8 @@ public class MindeeClientInit {
       mindeeSettings = new MindeeSettings();
     }
 
-    return new MindeeHttpApi(mindeeSettings);
+    return MindeeHttpApi.builder()
+      .mindeeSettings(mindeeSettings)
+      .build();
   }
 }

--- a/src/main/java/com/mindee/MindeeSettings.java
+++ b/src/main/java/com/mindee/MindeeSettings.java
@@ -1,5 +1,6 @@
 package com.mindee;
 
+import java.util.Optional;
 import lombok.Getter;
 
 /**
@@ -16,6 +17,11 @@ public class MindeeSettings {
     this("", "");
   }
 
+  public Optional<String> getApiKey()
+  {
+    return Optional.ofNullable(apiKey);
+  }
+
   public MindeeSettings(String apiKey) {
     this(apiKey, "");
   }
@@ -25,9 +31,10 @@ public class MindeeSettings {
     if (apiKey == null || apiKey.trim().isEmpty()) {
       String apiKeyFromEnv = System.getenv("MINDEE_API_KEY");
       if (apiKeyFromEnv == null || apiKeyFromEnv.trim().isEmpty()) {
-        throw new IllegalArgumentException("API KEY is null or empty.");
+        this.apiKey = null;
+      }else{
+        this.apiKey = apiKeyFromEnv;
       }
-      this.apiKey = apiKeyFromEnv;
     } else {
       this.apiKey = apiKey;
     }

--- a/src/main/java/com/mindee/MindeeSettings.java
+++ b/src/main/java/com/mindee/MindeeSettings.java
@@ -17,8 +17,7 @@ public class MindeeSettings {
     this("", "");
   }
 
-  public Optional<String> getApiKey()
-  {
+  public Optional<String> getApiKey() {
     return Optional.ofNullable(apiKey);
   }
 
@@ -32,7 +31,7 @@ public class MindeeSettings {
       String apiKeyFromEnv = System.getenv("MINDEE_API_KEY");
       if (apiKeyFromEnv == null || apiKeyFromEnv.trim().isEmpty()) {
         this.apiKey = null;
-      }else{
+      } else {
         this.apiKey = apiKeyFromEnv;
       }
     } else {

--- a/src/main/java/com/mindee/http/MindeeHttpApi.java
+++ b/src/main/java/com/mindee/http/MindeeHttpApi.java
@@ -44,7 +44,7 @@ public final class MindeeHttpApi implements MindeeApi {
 
   @Builder
   private MindeeHttpApi(MindeeSettings mindeeSettings, HttpClientBuilder httpClientBuilder,
-    Function<CustomEndpoint, String> urlFromEndpoint) {
+      Function<CustomEndpoint, String> urlFromEndpoint) {
     this.mindeeSettings = mindeeSettings;
 
     if (httpClientBuilder != null) {
@@ -64,8 +64,8 @@ public final class MindeeHttpApi implements MindeeApi {
    * POST a synchronous prediction request for a standard product.
    */
   public <DocT extends Inference> Document<DocT> predict(
-    Class<DocT> documentClass,
-    ParseParameter parseParameter
+      Class<DocT> documentClass,
+      ParseParameter parseParameter
   ) throws MindeeException, IOException {
 
     EndpointInfo endpointAnnotation = documentClass.getAnnotation(EndpointInfo.class);
@@ -74,24 +74,24 @@ public final class MindeeHttpApi implements MindeeApi {
     // that means it could be custom document
     if (endpointAnnotation == null) {
       CustomEndpointInfo customEndpointAnnotation = documentClass.getAnnotation(
-        CustomEndpointInfo.class
+          CustomEndpointInfo.class
       );
       if (customEndpointAnnotation == null) {
         throw new MindeeException(
-          "The class is not supported as a prediction model. "
-            + "The endpoint attribute is missing. "
-            + "Please refer to the document or contact the support."
+            "The class is not supported as a prediction model. "
+                + "The endpoint attribute is missing. "
+                + "Please refer to the document or contact the support."
         );
       }
       customEndpoint = new CustomEndpoint(
-        customEndpointAnnotation.endpointName(),
-        customEndpointAnnotation.accountName(),
-        customEndpointAnnotation.version());
+          customEndpointAnnotation.endpointName(),
+          customEndpointAnnotation.accountName(),
+          customEndpointAnnotation.version());
     } else {
       customEndpoint = new CustomEndpoint(
-        endpointAnnotation.endpointName(),
-        endpointAnnotation.accountName(),
-        endpointAnnotation.version());
+          endpointAnnotation.endpointName(),
+          endpointAnnotation.accountName(),
+          endpointAnnotation.version());
     }
 
     return predict(documentClass, customEndpoint, parseParameter);
@@ -101,9 +101,9 @@ public final class MindeeHttpApi implements MindeeApi {
    * POST a synchronous prediction request for a custom product.
    */
   public <DocT extends Inference> Document<DocT> predict(
-    Class<DocT> documentClass,
-    CustomEndpoint customEndpoint,
-    ParseParameter parseParameter
+      Class<DocT> documentClass,
+      CustomEndpoint customEndpoint,
+      ParseParameter parseParameter
   ) throws MindeeException, IOException {
 
     // required to register jackson date module format to deserialize
@@ -113,10 +113,10 @@ public final class MindeeHttpApi implements MindeeApi {
     MultipartEntityBuilder builder = MultipartEntityBuilder.create();
     builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
     builder.addBinaryBody(
-      "document",
-      parseParameter.getFile(),
-      ContentType.DEFAULT_BINARY,
-      parseParameter.getFileName()
+        "document",
+        parseParameter.getFile(),
+        ContentType.DEFAULT_BINARY,
+        parseParameter.getFileName()
     );
     if (Boolean.TRUE.equals(parseParameter.getIncludeWords())) {
       builder.addTextBody("include_mvision", "true");
@@ -133,15 +133,15 @@ public final class MindeeHttpApi implements MindeeApi {
     PredictResponse<DocT> predictResponse;
 
     try (
-      CloseableHttpClient httpClient = httpClientBuilder.build();
-      CloseableHttpResponse response = httpClient.execute(post)
+        CloseableHttpClient httpClient = httpClientBuilder.build();
+        CloseableHttpResponse response = httpClient.execute(post)
     ) {
       HttpEntity responseEntity = response.getEntity();
 
       if (responseEntity.getContentLength() != 0) {
         JavaType type = mapper.getTypeFactory().constructParametricType(
-          PredictResponse.class,
-          documentClass
+            PredictResponse.class,
+            documentClass
         );
         predictResponse = mapper.readValue(responseEntity.getContent(), type);
 
@@ -159,9 +159,9 @@ public final class MindeeHttpApi implements MindeeApi {
           contentRead.write(buffer, 0, length);
         }
         errorMessage += " Unhandled - HTTP Status code "
-          + response.getStatusLine().getStatusCode()
-          + " - Content "
-          + contentRead.toString("UTF-8");
+            + response.getStatusLine().getStatusCode()
+            + " - Content "
+            + contentRead.toString("UTF-8");
       }
     } catch (IOException err) {
       throw new MindeeException(err.getMessage(), err);
@@ -200,12 +200,12 @@ public final class MindeeHttpApi implements MindeeApi {
   private String buildUrl(CustomEndpoint customEndpoint) {
 
     return this.mindeeSettings.getBaseUrl()
-      + "/products/"
-      + customEndpoint.getAccountName()
-      + "/"
-      + customEndpoint.getEndpointName()
-      + "/v"
-      + customEndpoint.getVersion()
-      + "/predict";
+        + "/products/"
+        + customEndpoint.getAccountName()
+        + "/"
+        + customEndpoint.getEndpointName()
+        + "/v"
+        + customEndpoint.getVersion()
+        + "/predict";
   }
 }

--- a/src/main/java/com/mindee/http/MindeeHttpApi.java
+++ b/src/main/java/com/mindee/http/MindeeHttpApi.java
@@ -16,7 +16,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.function.Function;
 import lombok.Builder;
-import lombok.Value;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -30,13 +29,23 @@ import org.apache.http.impl.client.HttpClientBuilder;
 /**
  * HTTP Client class.
  */
-@Value
 public final class MindeeHttpApi implements MindeeApi {
 
   private static final ObjectMapper mapper = new ObjectMapper();
-  private MindeeSettings mindeeSettings;
-  private HttpClientBuilder httpClientBuilder;
-  private Function<CustomEndpoint, String> urlFromEndpoint;
+  /**
+   * The MindeeSetting needed to make the api call.
+   */
+  private final MindeeSettings mindeeSettings;
+  /**
+   * The HttpClientBuilder used to create HttpClient objects used to make api calls over http.
+   * Defaults to HttpClientBuilder.create().useSystemProperties()
+   */
+  private final HttpClientBuilder httpClientBuilder;
+  /**
+   * The function used to generate the API endpoint URL. Only needs to be set if the api calls need
+   * to be directed through internal URLs.
+   */
+  private final Function<CustomEndpoint, String> urlFromEndpoint;
 
   public MindeeHttpApi(MindeeSettings mindeeSettings) {
     this(mindeeSettings, null, null);

--- a/src/test/java/com/mindee/MindeeSettingsTest.java
+++ b/src/test/java/com/mindee/MindeeSettingsTest.java
@@ -3,26 +3,17 @@ package com.mindee;
 import junit.framework.TestCase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ClearEnvironmentVariable;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 public class MindeeSettingsTest extends TestCase {
 
-  @Test
-  @ClearEnvironmentVariable(key = "MINDEE_API_KEY")
-  @ClearEnvironmentVariable(key = "MINDEE_API_URL")
-  void clearedEnvironmentVariablesAndEmptyParams() {
-    Assertions.assertThrows(
-      IllegalArgumentException.class,
-      () -> new MindeeSettings("", ""));
-  }
 
   @Test
   @SetEnvironmentVariable(key = "MINDEE_API_KEY", value = "abcd")
   @SetEnvironmentVariable(key = "MINDEE_API_URL", value = "https://example.com")
   void setEnvironmentVariablesAndEmptyParams() {
     MindeeSettings settings = new MindeeSettings("", "");
-    Assertions.assertEquals(settings.getApiKey(), "abcd");
+    Assertions.assertEquals(settings.getApiKey().orElse(""), "abcd");
     Assertions.assertEquals(settings.getBaseUrl(), "https://example.com");
   }
 }

--- a/src/test/java/com/mindee/http/MindeeHttpApiTest.java
+++ b/src/test/java/com/mindee/http/MindeeHttpApiTest.java
@@ -1,22 +1,33 @@
 package com.mindee.http;
 
-import com.mindee.ParseParameter;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.mindee.MindeeSettings;
+import com.mindee.ParseParameter;
 import com.mindee.parsing.common.Document;
 import com.mindee.parsing.invoice.InvoiceV4Inference;
 import com.mindee.utils.MindeeException;
-import junit.framework.TestCase;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import junit.framework.TestCase;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.http.HttpHost;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MindeeHttpApiTest extends TestCase {
 
@@ -42,7 +53,10 @@ public class MindeeHttpApiTest extends TestCase {
       .setBody(new String(Files.readAllBytes(path))));
 
     File file = new File("src/test/resources/data/invoice/invoice.pdf");
-    MindeeHttpApi client = new MindeeHttpApi(new MindeeSettings("abc", url));
+    HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().useSystemProperties();
+
+    MindeeHttpApi client = MindeeHttpApi.builder().mindeeSettings(new MindeeSettings("abc", url))
+      .build();
     Document<InvoiceV4Inference> document = client.predict(
       InvoiceV4Inference.class,
       ParseParameter.builder()
@@ -63,23 +77,115 @@ public class MindeeHttpApiTest extends TestCase {
   }
 
   @Test
+  void givenAUrlBuilderFunction_whenParsed_callsTheCorrectUrl()
+    throws IOException, InterruptedException {
+
+    String url = String.format("http://localhost:%s", mockWebServer.getPort());
+    String mockPath = "/testinvoice/v2/test";
+    Path path = Paths.get("src/test/resources/data/invoice/response_v4/complete.json");
+    mockWebServer.enqueue(new MockResponse()
+      .setResponseCode(200)
+      .setBody(new String(Files.readAllBytes(path))));
+
+    File file = new File("src/test/resources/data/invoice/invoice.pdf");
+
+    MindeeHttpApi client = MindeeHttpApi.builder()
+      .mindeeSettings(new MindeeSettings("abc", url))
+      .urlFromEndpoint(
+        endpoint -> String.format("http://localhost:%s%s", mockWebServer.getPort(), mockPath))
+      .build();
+    Document<InvoiceV4Inference> document = client.predict(
+      InvoiceV4Inference.class,
+      ParseParameter.builder()
+        .file(Files.readAllBytes(file.toPath()))
+        .fileName(file.getName())
+        .build());
+
+    Assertions.assertNotNull(document);
+
+    String[] actualLines = document.toString().split(System.lineSeparator());
+    String actualSummary = String.join(String.format("%n"), actualLines);
+    List<String> expectedLines = Files
+      .readAllLines(Paths.get("src/test/resources/data/invoice/response_v4/summary_full.rst"));
+    String expectedSummary = String.join(String.format("%n"), expectedLines);
+
+    Assertions.assertNotNull(document);
+    Assertions.assertEquals(expectedSummary, actualSummary);
+    Assertions.assertEquals(mockPath, mockWebServer.takeRequest().getPath());
+  }
+
+  @Test
+  void givenAHttpClientBuilder_whenParseCalled_usesClientBuilderToMakeHttpClient()
+    throws IOException {
+
+    WireMockRule proxyMock = new WireMockRule();
+    proxyMock.start();
+    int proxyPort = proxyMock.port();
+
+    String url = String.format("http://localhost:%s", mockWebServer.getPort());
+
+    proxyMock.stubFor(post(urlMatching(".*"))
+      .willReturn(aResponse().proxiedFrom(url)));
+
+    Path path = Paths.get("src/test/resources/data/invoice/response_v4/complete.json");
+    mockWebServer.enqueue(new MockResponse()
+      .setResponseCode(200)
+      .setBody(new String(Files.readAllBytes(path))));
+
+    File file = new File("src/test/resources/data/invoice/invoice.pdf");
+
+    HttpHost proxy = new HttpHost("localhost", proxyPort);
+    DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
+    HttpClientBuilder httpclientBuilder = HttpClients.custom()
+      .setRoutePlanner(routePlanner);
+
+    MindeeHttpApi client = MindeeHttpApi.builder()
+      .mindeeSettings(new MindeeSettings("abc", url))
+      .httpClientBuilder(httpclientBuilder)
+      .build();
+    Document<InvoiceV4Inference> document = client.predict(
+      InvoiceV4Inference.class,
+      ParseParameter.builder()
+        .file(Files.readAllBytes(file.toPath()))
+        .fileName(file.getName())
+        .build());
+
+    Assertions.assertNotNull(document);
+
+    String[] actualLines = document.toString().split(System.lineSeparator());
+    String actualSummary = String.join(String.format("%n"), actualLines);
+    List<String> expectedLines = Files
+      .readAllLines(Paths.get("src/test/resources/data/invoice/response_v4/summary_full.rst"));
+    String expectedSummary = String.join(String.format("%n"), expectedLines);
+
+    proxyMock.verify(postRequestedFor(urlEqualTo("/products/Mindee/invoices/v4/predict"))
+      .withHeader("Authorization", containing("abc")));
+    Assertions.assertNotNull(document);
+    Assertions.assertEquals(expectedSummary, actualSummary);
+    proxyMock.shutdown();
+
+  }
+
+  @Test
   void givenError_withDetailNodeAsAnObject_mustThrowMindeeException()
     throws IOException {
 
     String url = String.format("http://localhost:%s", mockWebServer.getPort());
-    Path path = Paths.get("src/test/resources/data/errors/complete_with_object_response_in_detail.json");
+    Path path = Paths.get(
+      "src/test/resources/data/errors/complete_with_object_response_in_detail.json");
     mockWebServer.enqueue(new MockResponse()
       .setResponseCode(400)
       .setBody(new String(Files.readAllBytes(path))));
 
     File file = new File("src/test/resources/data/invoice/invoice.pdf");
-    MindeeHttpApi client = new MindeeHttpApi(new MindeeSettings("abc", url));
+    MindeeHttpApi client = MindeeHttpApi.builder().mindeeSettings(new MindeeSettings("abc", url))
+      .build();
     byte[] fileInBytes = Files.readAllBytes(file.toPath());
     ParseParameter parseParameter =
       ParseParameter.builder()
-      .file(fileInBytes)
-      .fileName(file.getName())
-      .build();
+        .file(fileInBytes)
+        .fileName(file.getName())
+        .build();
 
     Assertions.assertThrows(
       MindeeException.class,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
### MindeeClientInit
Added an overloaded create method that will allow the users of the sdk to pass their own custom implementation of the MindeeApi interface. 
### MindeeHttpApi
The provided MindeeApi implementation class can now be constructed to use a user provided HttpClientBuilder and URL Construction function. Also, the authorization header will only be set if one is available in the mindeesettings
### MindeeSettings
No longer throws an IAE if apikey is not set. Return type changed to Optional<String> for apiKey getter.
<!--- Why is this change required? What problem does it solve? -->

These changes are needed to allow users to use their own implementation (or customize the provided MindeeHttpAPI implementation). The MindeeSettings change is needed because with the custom HttpClientBuilder setting, the users are no longer obligated to provide an apikey - the key can now be set in the client builder they create, or they can potentially use their own authentication scheme with their internal proxy, and the proxy can add the mindee api key. 


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/orgs/mindee/projects/6/views/1?pane=issue&itemId=24649006


## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test using a mock server running as a proxy to another mock server that returns enqueued results
Manual testing to verify end to end flow works

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ X] Requires a change to the official Guide documentation.
