### PR TITLE
:sparkles: add ability to extract sub-images from PDFs

### DIFF
--- a/src/main/java/com/mindee/CommandLineInterface.java
+++ b/src/main/java/com/mindee/CommandLineInterface.java
@@ -11,6 +11,7 @@ import com.mindee.parsing.common.PredictResponse;
 import com.mindee.product.custom.CustomV1;
 import com.mindee.product.invoice.InvoiceV4;
 import com.mindee.product.invoicesplitter.InvoiceSplitterV1;
+import com.mindee.product.multireceiptsdetector.MultiReceiptsDetectorV1;
 import com.mindee.product.passport.PassportV1;
 import com.mindee.product.receipt.ReceiptV4;
 import java.io.File;
@@ -79,7 +80,7 @@ public class CommandLineInterface {
     System.exit(exitCode);
   }
 
-  @Command(name = "invoice", description = "Invokes the invoice API")
+  @Command(name = "invoice", description = "Invokes the Invoice API")
   void invoiceMethod(
       @Parameters(index = "0", paramLabel = "<path>", scope = ScopeType.LOCAL)
       File file
@@ -87,7 +88,7 @@ public class CommandLineInterface {
     System.out.println(standardProductOutput(InvoiceV4.class, file));
   }
 
-  @Command(name = "receipt", description = "Invokes the receipt API")
+  @Command(name = "receipt", description = "Invokes the Expense Receipt API")
   void receiptMethod(
       @Parameters(index = "0", paramLabel = "<path>", scope = ScopeType.LOCAL)
       File file
@@ -95,7 +96,15 @@ public class CommandLineInterface {
     System.out.println(standardProductOutput(ReceiptV4.class, file));
   }
 
-  @Command(name = "passport", description = "Invokes the passport API")
+  @Command(name = "multi-receipt-detector", description = "Invokes the Multi Receipts Detector API")
+  void multiReceiptDetectorMethod(
+      @Parameters(index = "0", paramLabel = "<path>", scope = ScopeType.LOCAL)
+      File file
+  ) throws IOException {
+    System.out.println(standardProductOutput(MultiReceiptsDetectorV1.class, file));
+  }
+
+  @Command(name = "passport", description = "Invokes the Passport API")
   void passportMethod(
       @Parameters(index = "0", paramLabel = "<path>", scope = ScopeType.LOCAL)
       File file
@@ -103,7 +112,7 @@ public class CommandLineInterface {
     System.out.println(standardProductOutput(PassportV1.class, file));
   }
 
-  @Command(name = "invoice-splitter", description = "Invokes the invoice-splitter API")
+  @Command(name = "invoice-splitter", description = "Invokes the Invoice Splitter API")
   void invoiceSplitterMethod(
       @Parameters(index = "0", paramLabel = "<path>", scope = ScopeType.LOCAL)
       File file
@@ -111,7 +120,7 @@ public class CommandLineInterface {
     System.out.println(standardProductAsyncOutput(InvoiceSplitterV1.class, file));
   }
 
-  @Command(name = "custom", description = "Invokes a builder API")
+  @Command(name = "custom", description = "Invokes a Custom API")
   void customMethod(
       @Option(
           names = {"-a", "--account"},

--- a/src/main/java/com/mindee/MindeeClient.java
+++ b/src/main/java/com/mindee/MindeeClient.java
@@ -492,8 +492,7 @@ public class MindeeClient {
       PageOptions pageOptions
   ) throws IOException {
     byte[] splitFile;
-    boolean isPDF = InputSourceUtils.isPdf(localInputSource.getFilename());
-    if (pageOptions == null || !isPDF) {
+    if (pageOptions == null || !localInputSource.isPdf()) {
       splitFile = localInputSource.getFile();
     } else {
       splitFile = pdfOperation.split(

--- a/src/main/java/com/mindee/extraction/ImageExtractor.java
+++ b/src/main/java/com/mindee/extraction/ImageExtractor.java
@@ -1,14 +1,16 @@
 package com.mindee.extraction;
 
+import com.mindee.MindeeException;
 import com.mindee.geometry.Bbox;
 import com.mindee.geometry.BboxUtils;
 import com.mindee.geometry.Polygon;
 import com.mindee.input.InputSourceUtils;
 import com.mindee.input.LocalInputSource;
 import com.mindee.parsing.standard.PositionData;
+import com.mindee.pdf.PDFUtils;
+import com.mindee.pdf.PdfPageImage;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,17 +20,16 @@ import javax.imageio.ImageIO;
  * Extract sub-images from an image.
  */
 public class ImageExtractor {
-  private final BufferedImage bufferedImage;
+  private final List<BufferedImage> pageImages;
   private final String filename;
+  private final String saveFormat;
 
   /**
    * Init from a path.
    * @param filePath Path to the file.
    */
   public ImageExtractor(String filePath) throws IOException {
-    File file = new File(filePath);
-    this.filename = file.getName();
-    this.bufferedImage = ImageIO.read(file);
+    this(new LocalInputSource(filePath));
   }
 
   /**
@@ -37,12 +38,33 @@ public class ImageExtractor {
    */
   public ImageExtractor(LocalInputSource source) throws IOException {
     this.filename = source.getFilename();
-    ByteArrayInputStream input = new ByteArrayInputStream(source.getFile());
-    this.bufferedImage = ImageIO.read(input);
+    this.pageImages = new ArrayList<>();
+
+    if (source.isPdf()) {
+      this.saveFormat = "jpg";
+      List<PdfPageImage> pdfPageImages = PDFUtils.pdfToImages(source);
+      for (PdfPageImage pdfPageImage : pdfPageImages) {
+        this.pageImages.add(pdfPageImage.getImage());
+      }
+    } else {
+      String[] splitName = InputSourceUtils.splitNameStrict(this.filename);
+      this.saveFormat = splitName[1].toLowerCase();
+
+      ByteArrayInputStream input = new ByteArrayInputStream(source.getFile());
+      this.pageImages.add(ImageIO.read(input));
+    }
+  }
+
+  /**
+   * @return The number of pages in the file.
+   */
+  public int getPageCount() {
+    return this.pageImages.size();
   }
 
   /**
    * Extract images from a list of fields having position data.
+   * Use this when the input file is an image or a single-page PDF.
    * @param fields List of Fields to extract.
    * @return A list of {@link ExtractedImage}.
    */
@@ -52,14 +74,67 @@ public class ImageExtractor {
 
   /**
    * Extract images from a list of fields having position data.
+   * Use this when the input file is an image or a single-page PDF.
    * @param fields List of Fields to extract.
-   * @param filename The base output filename.
+   * @param outputName The base output filename, must have an image extension.
    * @return A list of {@link ExtractedImage}.
    */
-  public <FieldT extends PositionData> List<ExtractedImage> extractImages(List<FieldT> fields, String filename) {
+  public <FieldT extends PositionData> List<ExtractedImage> extractImages(List<FieldT> fields, String outputName) {
+    if (this.getPageCount() > 1) {
+      throw new MindeeException("Input file has more than one page, use the `extractPageImages` method instead.");
+    }
+    return extractFromPage(fields, 0, outputName);
+  }
+
+  /**
+   * Extract images from a list of fields having position data.
+   * Use this when the input file is a PDF with multiple pages.
+   * @param fields List of Fields to extract.
+   * @param pageIndex The page index to extract, begins at 0.
+   * @return A list of {@link ExtractedImage}.
+   */
+  public <FieldT extends PositionData> List<ExtractedImage> extractPageImages(
+      List<FieldT> fields,
+      int pageIndex
+  ) {
+    return extractPageImages(fields, pageIndex, this.filename);
+  }
+
+  /**
+   * Extract images from a list of fields having position data.
+   * Use this when the input file is a PDF with multiple pages.
+   * @param fields List of Fields to extract.
+   * @param pageIndex The page index to extract, begins at 0.
+   * @param outputName The base output filename, must have an image extension.
+   * @return A list of {@link ExtractedImage}.
+   */
+  public <FieldT extends PositionData> List<ExtractedImage> extractPageImages(
+      List<FieldT> fields,
+      int pageIndex,
+      String outputName
+  ) {
+    String filename;
+    if (this.getPageCount() > 1) {
+      String[] splitName = InputSourceUtils.splitNameStrict(outputName);
+      filename = splitName[0] + "." + this.saveFormat;
+    } else {
+      filename = this.filename;
+    }
+    return extractFromPage(fields, pageIndex, filename);
+  }
+
+  private <FieldT extends PositionData> List<ExtractedImage> extractFromPage(
+      List<FieldT> fields,
+      int pageIndex,
+      String outputName
+  ) {
+    String[] splitName = InputSourceUtils.splitNameStrict(outputName);
+    String filename = String.format("%s_page-%3s.%s", splitName[0], pageIndex + 1, splitName[1])
+        .replace(" ", "0");
+
     List<ExtractedImage> extractedImages = new ArrayList<>();
     for (int i = 0; i < fields.size(); i++) {
-      ExtractedImage extractedImage = extractImage(fields.get(i), filename, i+1);
+      ExtractedImage extractedImage = extractImage(fields.get(i), pageIndex, i+1, filename);
       if (extractedImage != null) {
         extractedImages.add(extractedImage);
       }
@@ -71,9 +146,15 @@ public class ImageExtractor {
    * Extract an image from a field having position data.
    * @param field The field to extract.
    * @param index The index to use for naming the extracted image.
+   * @param pageIndex The page index to extract, begins at 0.
    * @return The {@link ExtractedImage}, or <code>null</code> if the field does not have valid position data.
    */
-  public <FieldT extends PositionData> ExtractedImage extractImage(FieldT field, String filename, int index) {
+  public <FieldT extends PositionData> ExtractedImage extractImage(
+      FieldT field,
+      int pageIndex,
+      int index,
+      String filename
+  ) {
     String[] splitName = InputSourceUtils.splitNameStrict(filename);
     String saveFormat = splitName[1].toLowerCase();
     Polygon boundingBox = field.getBoundingBox();
@@ -84,27 +165,29 @@ public class ImageExtractor {
     String fieldFilename = splitName[0]
         + String.format("_%3s", index).replace(" ", "0")
         + "."
-        + splitName[1];
-    return new ExtractedImage(extractImage(bbox), fieldFilename, saveFormat);
+        + saveFormat;
+    return new ExtractedImage(extractImage(bbox, pageIndex), fieldFilename, saveFormat);
   }
 
   /**
    * Extract an image from a field having position data.
    * @param field The field to extract.
    * @param index The index to use for naming the extracted image.
+   * @param pageIndex The page index to extract, begins at 0.
    * @return The {@link ExtractedImage}, or <code>null</code> if the field does not have valid position data.
    */
-  public <FieldT extends PositionData> ExtractedImage extractImage(FieldT field, int index) {
-    return extractImage(field, this.filename, index);
+  public <FieldT extends PositionData> ExtractedImage extractImage(FieldT field, int pageIndex, int index) {
+    return extractImage(field, pageIndex, index, this.filename);
   }
 
-  private BufferedImage extractImage(Bbox bbox) {
-    int width = this.bufferedImage.getWidth();
-    int height = this.bufferedImage.getHeight();
+  private BufferedImage extractImage(Bbox bbox, int pageIndex) {
+    BufferedImage image = this.pageImages.get(pageIndex);
+    int width = image.getWidth();
+    int height = image.getHeight();
     int minX = (int) Math.round(bbox.getMinX() * width);
     int maxX = (int) Math.round(bbox.getMaxX() * width);
     int minY = (int) Math.round(bbox.getMinY() * height);
     int maxY = (int) Math.round(bbox.getMaxY() * height);
-    return this.bufferedImage.getSubimage(minX, minY, maxX - minX, maxY - minY);
+    return image.getSubimage(minX, minY, maxX - minX, maxY - minY);
   }
 }

--- a/src/main/java/com/mindee/extraction/ImageExtractor.java
+++ b/src/main/java/com/mindee/extraction/ImageExtractor.java
@@ -1,6 +1,5 @@
 package com.mindee.extraction;
 
-import com.mindee.MindeeException;
 import com.mindee.geometry.Bbox;
 import com.mindee.geometry.BboxUtils;
 import com.mindee.geometry.Polygon;
@@ -64,40 +63,16 @@ public class ImageExtractor {
 
   /**
    * Extract images from a list of fields having position data.
-   * Use this when the input file is an image or a single-page PDF.
-   * @param fields List of Fields to extract.
-   * @return A list of {@link ExtractedImage}.
-   */
-  public <FieldT extends PositionData> List<ExtractedImage> extractImages(List<FieldT> fields) {
-    return extractImages(fields, this.filename);
-  }
-
-  /**
-   * Extract images from a list of fields having position data.
-   * Use this when the input file is an image or a single-page PDF.
-   * @param fields List of Fields to extract.
-   * @param outputName The base output filename, must have an image extension.
-   * @return A list of {@link ExtractedImage}.
-   */
-  public <FieldT extends PositionData> List<ExtractedImage> extractImages(List<FieldT> fields, String outputName) {
-    if (this.getPageCount() > 1) {
-      throw new MindeeException("Input file has more than one page, use the `extractPageImages` method instead.");
-    }
-    return extractFromPage(fields, 0, outputName);
-  }
-
-  /**
-   * Extract images from a list of fields having position data.
    * Use this when the input file is a PDF with multiple pages.
    * @param fields List of Fields to extract.
    * @param pageIndex The page index to extract, begins at 0.
    * @return A list of {@link ExtractedImage}.
    */
-  public <FieldT extends PositionData> List<ExtractedImage> extractPageImages(
+  public <FieldT extends PositionData> List<ExtractedImage> extractImagesFromPage(
       List<FieldT> fields,
       int pageIndex
   ) {
-    return extractPageImages(fields, pageIndex, this.filename);
+    return extractImagesFromPage(fields, pageIndex, this.filename);
   }
 
   /**
@@ -108,7 +83,7 @@ public class ImageExtractor {
    * @param outputName The base output filename, must have an image extension.
    * @return A list of {@link ExtractedImage}.
    */
-  public <FieldT extends PositionData> List<ExtractedImage> extractPageImages(
+  public <FieldT extends PositionData> List<ExtractedImage> extractImagesFromPage(
       List<FieldT> fields,
       int pageIndex,
       String outputName
@@ -118,7 +93,7 @@ public class ImageExtractor {
       String[] splitName = InputSourceUtils.splitNameStrict(outputName);
       filename = splitName[0] + "." + this.saveFormat;
     } else {
-      filename = this.filename;
+      filename = outputName;
     }
     return extractFromPage(fields, pageIndex, filename);
   }

--- a/src/main/java/com/mindee/input/LocalInputSource.java
+++ b/src/main/java/com/mindee/input/LocalInputSource.java
@@ -42,4 +42,8 @@ public final class LocalInputSource {
     this.file = Base64.getDecoder().decode(fileAsBase64.getBytes());
     this.filename = filename;
   }
+
+  public boolean isPdf() {
+    return InputSourceUtils.isPdf(this.filename);
+  }
 }

--- a/src/test/java/com/mindee/extraction/ImageExtractorTest.java
+++ b/src/test/java/com/mindee/extraction/ImageExtractorTest.java
@@ -2,7 +2,9 @@ package com.mindee.extraction;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mindee.MindeeException;
 import com.mindee.input.LocalInputSource;
+import com.mindee.parsing.common.Page;
 import com.mindee.parsing.common.PredictResponse;
 import com.mindee.product.barcodereader.BarcodeReaderV1;
 import com.mindee.product.barcodereader.BarcodeReaderV1Document;
@@ -54,6 +56,8 @@ public class ImageExtractorTest {
     MultiReceiptsDetectorV1Document prediction = response.getDocument().getInference().getPrediction();
 
     ImageExtractor extractor = new ImageExtractor(image);
+    Assertions.assertEquals(1, extractor.getPageCount());
+
     List<ExtractedImage> subImages = extractor.extractImages(prediction.getReceipts());
     for (int i = 0; i < subImages.size(); i++) {
       ExtractedImage extractedImage = subImages.get(i);
@@ -62,7 +66,7 @@ public class ImageExtractorTest {
 
       LocalInputSource source = extractedImage.asInputSource();
       Assertions.assertEquals(
-          String.format("default_sample_%3s.jpg", i + 1).replace(" ", "0"),
+          String.format("default_sample_page-001_%3s.jpg", i + 1).replace(" ", "0"),
           source.getFilename()
       );
     }
@@ -75,15 +79,59 @@ public class ImageExtractorTest {
     BarcodeReaderV1Document prediction = response.getDocument().getInference().getPrediction();
 
     ImageExtractor extractor = new ImageExtractor(imagePath);
+    Assertions.assertEquals(1, extractor.getPageCount());
+
     List<ExtractedImage> codes1D = extractor.extractImages(prediction.getCodes1D(), "barcodes_1D.png");
-    for (ExtractedImage extractedImage : codes1D) {
+    for (int i = 0; i < codes1D.size(); i++) {
+      ExtractedImage extractedImage = codes1D.get(i);
       Assertions.assertNotNull(extractedImage.getImage());
+      LocalInputSource source = extractedImage.asInputSource();
+      Assertions.assertEquals(
+        String.format("barcodes_1D_page-001_%3s.png", i + 1).replace(" ", "0"),
+        source.getFilename()
+      );
       extractedImage.writeToFile("src/test/resources/output/");
     }
     List<ExtractedImage> codes2D = extractor.extractImages(prediction.getCodes2D(), "barcodes_2D.png");
     for (ExtractedImage extractedImage : codes2D) {
       Assertions.assertNotNull(extractedImage.getImage());
       extractedImage.writeToFile("src/test/resources/output/");
+    }
+  }
+
+  @Test
+  public void givenAPdf_shouldExtractPositionFields() throws IOException {
+    LocalInputSource image = new LocalInputSource(
+      "src/test/resources/products/multi_receipts_detector/multipage_sample.pdf"
+    );
+    PredictResponse<MultiReceiptsDetectorV1> response = getMultiReceiptsPrediction("multipage_sample");
+    MultiReceiptsDetectorV1 inference = response.getDocument().getInference();
+
+    ImageExtractor extractor = new ImageExtractor(image);
+    Assertions.assertEquals(2, extractor.getPageCount());
+
+    Assertions.assertThrows(
+      MindeeException.class,
+      () -> extractor.extractImages(inference.getPrediction().getReceipts())
+    );
+
+    for (Page<MultiReceiptsDetectorV1Document> page : inference.getPages()) {
+      List<ExtractedImage> subImages = extractor.extractPageImages(
+        page.getPrediction().getReceipts(),
+        page.getPageId()
+      );
+
+      for (int i = 0; i < subImages.size(); i++) {
+        ExtractedImage extractedImage = subImages.get(i);
+        Assertions.assertNotNull(extractedImage.getImage());
+        extractedImage.writeToFile("src/test/resources/output/");
+
+        LocalInputSource source = extractedImage.asInputSource();
+        Assertions.assertEquals(
+          String.format("multipage_sample_page-%3s_%3s.jpg", page.getPageId() + 1,  i + 1).replace(" ", "0"),
+          source.getFilename()
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
Add the ability to extract sub-images from individual pages.

Auto-detect if the source image is a PDF when constructing the image extractor.
If it's a PDF, extract each PDF page to an individual image.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
