### PR TITLE
:bug: fix for not closing the PDF document

### DIFF
--- a/src/main/java/com/mindee/pdf/PDFUtils.java
+++ b/src/main/java/com/mindee/pdf/PDFUtils.java
@@ -105,9 +105,10 @@ public final class PDFUtils {
     PDFRenderer pdfRenderer = new PDFRenderer(document);
     List<PdfPageImage> pdfPageImages = new ArrayList<>();
     for (int i = 0; i < document.getNumberOfPages(); i++) {
-      BufferedImage imageBuffer = pdfRenderer.renderImageWithDPI(i, 220, ImageType.RGB);
+      BufferedImage imageBuffer = pdfRenderer.renderImageWithDPI(i, 200, ImageType.RGB);
       pdfPageImages.add(new PdfPageImage(imageBuffer, i, source.getFilename(), "jpg"));
     }
+    document.close();
     return pdfPageImages;
   }
 }


### PR DESCRIPTION
## Description
Avoid a warning when the PDF file is not closed after extracting images.

Lower DPI on extracted images for bandwidth and processing considerations.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
