### PR TITLE
:sparkles: allow converting between bboxes and polygons

### DIFF
--- a/src/main/java/com/mindee/geometry/Bbox.java
+++ b/src/main/java/com/mindee/geometry/Bbox.java
@@ -1,5 +1,8 @@
 package com.mindee.geometry;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Getter;
 
 /**
@@ -17,11 +20,8 @@ public final class Bbox {
    * The default constructor.
    *
    * @param minX The minimum X coordinate.
-   *
    * @param maxX The maximum X coordinate.
-   *
    * @param minY The minimal Y coordinate.
-   *
    * @param maxY The maximum Y coordinate.
    */
   public Bbox(double minX, double maxX, double minY, double maxY) {
@@ -29,5 +29,20 @@ public final class Bbox {
     this.minY = minY;
     this.maxX = maxX;
     this.maxY = maxY;
+  }
+
+  /**
+   * Get the Bbox as a Polygon.
+   */
+  public Polygon getAsPolygon() {
+    List<Point> points = new ArrayList<>(
+        Arrays.asList(
+          new Point(this.minX, this.minY),
+          new Point(this.maxX, this.minY),
+          new Point(this.maxX, this.maxY),
+          new Point(this.minX, this.maxY)
+        )
+    );
+    return new Polygon(points);
   }
 }

--- a/src/main/java/com/mindee/geometry/Point.java
+++ b/src/main/java/com/mindee/geometry/Point.java
@@ -8,9 +8,9 @@ import lombok.extern.jackson.Jacksonized;
  * A relative set of coordinates (X, Y) on the document.
  */
 @Value
-public final class Point {
-  private Double x;
-  private Double y;
+public class Point {
+  Double x;
+  Double y;
 
   @Builder
   @Jacksonized
@@ -19,4 +19,15 @@ public final class Point {
     this.y = y;
   }
 
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || this.getClass() != object.getClass()) {
+      return false;
+    }
+    Point point = (Point) object;
+    return this.x.equals(point.x) && this.y.equals(point.y);
+  }
 }

--- a/src/main/java/com/mindee/geometry/Polygon.java
+++ b/src/main/java/com/mindee/geometry/Polygon.java
@@ -20,6 +20,13 @@ public class Polygon {
   }
 
   /**
+   * Get the polygon as a Bbox.
+   */
+  public Bbox getAsBbox() {
+    return BboxUtils.generate(this);
+  }
+
+  /**
    * Get the central coordinates (centroid) of the Polygon.
    */
   public Point getCentroid() {
@@ -52,5 +59,25 @@ public class Polygon {
       return String.format("Polygon with %s points.", getCoordinates().size());
     }
     return "";
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || this.getClass() != object.getClass()) {
+      return false;
+    }
+    Polygon polygon = (Polygon) object;
+    if (this.coordinates.size() != polygon.coordinates.size()) {
+      return false;
+    }
+    for (int i = 0; i < this.coordinates.size(); i++) {
+      if (!this.coordinates.get(i).equals(polygon.coordinates.get(i))) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/main/java/com/mindee/parsing/custom/lineitems/LineGenerator.java
+++ b/src/main/java/com/mindee/parsing/custom/lineitems/LineGenerator.java
@@ -39,12 +39,12 @@ public final class LineGenerator {
     int lineNumber = 1;
     Line currentLine = new Line(lineNumber, fieldAsAnchor.getTolerance());
     ListFieldValue currentValue = anchor.getValues().get(0);
-    currentLine.setBbox(BboxUtils.generate(currentValue.getPolygon()));
+    currentLine.setBbox(currentValue.getPolygon().getAsBbox());
 
     for (int i = 1; i < anchor.getValues().size(); i++) {
 
       currentValue = anchor.getValues().get(i);
-      Bbox currentFieldBbox = BboxUtils.generate(currentValue.getPolygon());
+      Bbox currentFieldBbox = currentValue.getPolygon().getAsBbox();
 
       if (
           Precision.equals(

--- a/src/test/java/com/mindee/geometry/BboxUtilsTest.java
+++ b/src/test/java/com/mindee/geometry/BboxUtilsTest.java
@@ -3,31 +3,48 @@ package com.mindee.geometry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class BboxUtilsTest {
 
+  private static final Polygon polyA = new Polygon(
+    Arrays.asList(
+      new Point(0.081, 0.442),
+      new Point(0.15, 0.442),
+      new Point(0.15, 0.451),
+      new Point(0.081, 0.451)
+    )
+  );
+  private static final Bbox bboxA = new Bbox(
+    0.081, 0.15, 0.442, 0.451
+  );
+
   @Test
-  public void with0PolygonMustGetNull() {
+  public void withZeroPolygonMustGetNull() {
     List<Polygon> polygons = new ArrayList<>();
-
     Bbox bbox = BboxUtils.generate(polygons);
-
     Assertions.assertNull(bbox);
   }
 
   @Test
-  public void with1PolygonAndANullPolygonMustGetNull() {
-    List<Polygon> polygons = Arrays.asList(
-      new Polygon(Arrays.asList(
-        new Point(0.081, 0.442),
-        new Point(0.15, 0.442),
-        new Point(0.15, 0.451),
-        new Point(0.081, 0.451))),
-      null);
+  public void withPolygonMustGetValidBbox() {
+    Bbox bbox = BboxUtils.generate(BboxUtilsTest.polyA);
 
+    Assertions.assertEquals(0.442, bbox.getMinY());
+    Assertions.assertEquals(0.081, bbox.getMinX());
+    Assertions.assertEquals(0.451, bbox.getMaxY());
+    Assertions.assertEquals(0.15, bbox.getMaxX());
+
+    Assertions.assertEquals(BboxUtilsTest.polyA, bbox.getAsPolygon());
+  }
+
+  @Test
+  public void withOnePolygonAndANullPolygonMustGetNull() {
+    List<Polygon> polygons = Arrays.asList(
+      BboxUtilsTest.polyA,
+      null
+    );
     Bbox bbox = BboxUtils.generate(polygons);
 
     Assertions.assertEquals(0.442, bbox.getMinY());
@@ -39,12 +56,8 @@ class BboxUtilsTest {
   @Test
   public void withOnePolygonMustGetValidBbox() {
     List<Polygon> polygons = Arrays.asList(
-      new Polygon(Arrays.asList(
-        new Point(0.081, 0.442),
-        new Point(0.15, 0.442),
-        new Point(0.15, 0.451),
-        new Point(0.081, 0.451))));
-
+      BboxUtilsTest.polyA
+    );
     Bbox bbox = BboxUtils.generate(polygons);
 
     Assertions.assertEquals(0.442, bbox.getMinY());
@@ -56,11 +69,7 @@ class BboxUtilsTest {
   @Test
   public void withTwoPolygonsMustGetValidBbox() {
     List<Polygon> polygons = Arrays.asList(
-      new Polygon(Arrays.asList(
-        new Point(0.081, 0.442),
-        new Point(0.15, 0.442),
-        new Point(0.15, 0.451),
-        new Point(0.081, 0.451))),
+      BboxUtilsTest.polyA,
       new Polygon(Arrays.asList(
         new Point(0.157, 0.442),
         new Point(0.26, 0.442),
@@ -78,7 +87,7 @@ class BboxUtilsTest {
   @Test
   public void merge2BboxMustGetValidBbox() {
     List<Bbox> bboxs = Arrays.asList(
-      new Bbox(0.081, 0.15, 0.442, 0.451),
+      BboxUtilsTest.bboxA,
       new Bbox(0.157, 0.26, 0.442, 0.451));
 
     Bbox bbox = BboxUtils.merge(bboxs);


### PR DESCRIPTION
## Description
Add the ability to convert `Bbox` to and from `Polygon` objects.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
