### PR TITLE
:sparkles: allow sending multiple anchors when building line items

### DIFF
--- a/src/main/java/com/mindee/parsing/custom/lineitems/LineItemsGenerator.java
+++ b/src/main/java/com/mindee/parsing/custom/lineitems/LineItemsGenerator.java
@@ -1,10 +1,10 @@
 package com.mindee.parsing.custom.lineitems;
 
 import com.mindee.geometry.MinMax;
-import com.mindee.geometry.PolygonUtils;
 import com.mindee.parsing.custom.ListField;
 import com.mindee.parsing.custom.ListFieldValue;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -19,8 +19,25 @@ public final class LineItemsGenerator {
   }
 
   /**
-   * WARNING: This feature is experimental!
-   * Results may not always work as intended.
+   * Generate line items.
+   * Use this method if you want to send a list of different possible anchor fields.
+   * Will use the tolerance settings from the best anchor.
+   */
+  public static LineItems generate(
+      List<String> fieldNames,
+      Map<String, ListField> fields,
+      List<Anchor> anchors
+  ) {
+    Map<String, ListField> fieldsToTransformIntoLines = fields.entrySet()
+        .stream()
+        .filter(field -> fieldNames.contains(field.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    return generate(fieldsToTransformIntoLines, anchors);
+  }
+
+  /**
+   * Generate line items.
+   * Use this method if you want to use a single anchor field.
    */
   public static LineItems generate(
       List<String> fieldNames,
@@ -31,20 +48,32 @@ public final class LineItemsGenerator {
         .stream()
         .filter(field -> fieldNames.contains(field.getKey()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    List<Anchor> anchors = new ArrayList<>(
+        Collections.singletonList(anchor)
+    );
+    return generate(fieldsToTransformIntoLines, anchors);
+  }
 
+  private static LineItems generate(
+      Map<String, ListField> fieldsToTransformIntoLines,
+      List<Anchor> anchors
+  ) {
+    PreparedLines preparedLines = LineGenerator.prepareLines(
+        fieldsToTransformIntoLines,
+        anchors
+    );
     List<Line> lines = populateLines(
         fieldsToTransformIntoLines,
-        new ArrayList<>(LineGenerator.prepareLines(fieldsToTransformIntoLines, anchor)),
-        anchor.getTolerance()
+        preparedLines.getLines(),
+        preparedLines.getAnchor().getTolerance()
     );
-
     return new LineItems(lines);
   }
 
   private static List<Line> populateLines(
       Map<String, ListField> fields,
       List<Line> lines,
-      double heightLineTolerance
+      double tolerance
   ) {
     List<Line> populatedLines = new ArrayList<>();
 
@@ -54,8 +83,8 @@ public final class LineItemsGenerator {
           MinMax minMaxY = listFieldValue.getPolygon().getMinMaxY();
 
           if (
-              Math.abs(minMaxY.getMax() - currentLine.getBbox().getMaxY()) <= heightLineTolerance
-              && Math.abs(minMaxY.getMin() - currentLine.getBbox().getMinY()) <= heightLineTolerance
+              Math.abs(minMaxY.getMax() - currentLine.getBbox().getMaxY()) <= tolerance
+              && Math.abs(minMaxY.getMin() - currentLine.getBbox().getMinY()) <= tolerance
           ) {
             currentLine.addField(field.getKey(), listFieldValue);
           }

--- a/src/main/java/com/mindee/parsing/custom/lineitems/PreparedLines.java
+++ b/src/main/java/com/mindee/parsing/custom/lineitems/PreparedLines.java
@@ -1,0 +1,21 @@
+package com.mindee.parsing.custom.lineitems;
+
+import java.util.List;
+import lombok.Getter;
+
+/**
+ * An anchor and its initial lines.
+ */
+@Getter
+public final class PreparedLines {
+  private final Anchor anchor;
+  private final List<Line> lines;
+
+  /**
+   * An anchor and its initial lines.
+   */
+  public PreparedLines(Anchor anchor, List<Line> lines) {
+    this.anchor = anchor;
+    this.lines = lines;
+  }
+}

--- a/src/test/java/com/mindee/parsing/custom/lineitems/FakeListField.java
+++ b/src/test/java/com/mindee/parsing/custom/lineitems/FakeListField.java
@@ -12,6 +12,89 @@ class FakeListField {
   private FakeListField() {
   }
 
+  static Map<String, ListField> get2completeLines1halfLine() {
+    Map<String, ListField> fakes = new HashMap<>();
+    fakes.put(
+      "birthDates",
+      new ListField(
+        1.0,
+        Arrays.asList(
+          new ListFieldValue(
+            "1986-10-23",
+            1.0,
+            new Polygon(
+              Arrays.asList(
+                new Point(0.818, 0.398),
+                new Point(0.902, 0.398),
+                new Point(0.902, 0.406),
+                new Point(0.818, 0.406)))),
+          new ListFieldValue(
+            "2012-02-13",
+            1.0,
+            new Polygon(
+              Arrays.asList(
+                new Point(0.819, 0.442),
+                new Point(0.902, 0.442),
+                new Point(0.902, 0.451),
+                new Point(0.819, 0.451)))),
+          new ListFieldValue(
+            "1895-02-28",
+            1.0,
+            new Polygon(
+              Arrays.asList(
+                new Point(0.819, 0.462),
+                new Point(0.902, 0.462),
+                new Point(0.902, 0.471),
+                new Point(0.819, 0.471))))
+        ))
+    );
+    fakes.put(
+      "names",
+      new ListField(
+        1.0,
+        Arrays.asList(
+          new ListFieldValue(
+            "Kevin",
+            1.0,
+            new Polygon(
+              Arrays.asList(
+                new Point(0.082, 0.398),
+                new Point(0.144, 0.398),
+                new Point(0.144, 0.407),
+                new Point(0.082, 0.407)))),
+          new ListFieldValue(
+            "Mindee",
+            1.0,
+            new Polygon(
+              Arrays.asList(
+                new Point(0.152, 0.398),
+                new Point(0.222, 0.398),
+                new Point(0.222, 0.407),
+                new Point(0.152, 0.407)))),
+          new ListFieldValue(
+            "Ianaré",
+            1.0,
+            new Polygon(
+              Arrays.asList(
+                new Point(0.081, 0.442),
+                new Point(0.15, 0.442),
+                new Point(0.15, 0.451),
+                new Point(0.081, 0.451)))),
+          new ListFieldValue(
+            "Mindee",
+            1.0,
+            new Polygon(
+              Arrays.asList(
+                new Point(0.157, 0.442),
+                new Point(0.26, 0.442),
+                new Point(0.26, 0.451),
+                new Point(0.157, 0.451))))
+        ))
+    );
+
+    return fakes;
+  }
+
   static Map<String, ListField> getWith2ValuesByExpectedLines() {
     Map<String, ListField> fakes = new HashMap<>();
     fakes.put(
@@ -36,7 +119,8 @@ class FakeListField {
                 new Point(0.819, 0.442),
                 new Point(0.902, 0.442),
                 new Point(0.902, 0.451),
-                new Point(0.819, 0.451))))))
+                new Point(0.819, 0.451))))
+        ))
     );
 
     fakes.put(
@@ -79,7 +163,8 @@ class FakeListField {
                         new Point(0.157, 0.442),
                         new Point(0.26, 0.442),
                         new Point(0.26, 0.451),
-                        new Point(0.157, 0.451))))))
+                        new Point(0.157, 0.451))))
+        ))
     );
 
     return fakes;
@@ -110,7 +195,8 @@ class FakeListField {
                         new Point(0.819, 0.442),
                         new Point(0.902, 0.442),
                         new Point(0.902, 0.451),
-                        new Point(0.819, 0.451))))))
+                        new Point(0.819, 0.451))))
+        ))
     );
 
     fakes.put(
@@ -162,7 +248,8 @@ class FakeListField {
                         new Point(0.082, 0.486),
                         new Point(0.151, 0.486),
                         new Point(0.151, 0.495),
-                        new Point(0.082, 0.495))))))
+                        new Point(0.082, 0.495))))
+        ))
     );
 
     return fakes;
@@ -170,7 +257,6 @@ class FakeListField {
 
   static Map<String, ListField> getWith1ExpectedLines() {
     Map<String, ListField> fakes = new HashMap<>();
-
     fakes.put(
       "birthDates",
       new ListField(
@@ -184,9 +270,9 @@ class FakeListField {
                           new Point(0.818, 0.398),
                           new Point(0.902, 0.398),
                           new Point(0.902, 0.406),
-                          new Point(0.818, 0.406))))))
+                          new Point(0.818, 0.406))))
+          ))
     );
-
     fakes.put(
       "names",
       new ListField(
@@ -209,15 +295,14 @@ class FakeListField {
                         new Point(0.152, 0.398),
                         new Point(0.222, 0.398),
                         new Point(0.222, 0.407),
-                        new Point(0.152, 0.407))))))
+                        new Point(0.152, 0.407))))
+        ))
     );
-
     return fakes;
   }
 
-  static Map<String, ListField>  getWithPolygonsNotExactlyOnTheSameAxis() {
+  static Map<String, ListField> getWithPolygonsNotExactlyOnTheSameAxis() {
     Map<String, ListField> fakes = new HashMap<>();
-
     fakes.put(
       "birthDates",
       new ListField(
@@ -240,9 +325,9 @@ class FakeListField {
                         new Point(0.581, 0.45),
                         new Point(0.656, 0.45),
                         new Point(0.656, 0.458),
-                        new Point(0.581, 0.458))))))
+                        new Point(0.581, 0.458))))
+        ))
     );
-
     fakes.put(
       "names",
       new ListField(
@@ -274,15 +359,14 @@ class FakeListField {
                         new Point(0.118, 0.45),
                         new Point(0.169, 0.451),
                         new Point(0.169, 0.458),
-                        new Point(0.117, 0.457))))))
+                        new Point(0.117, 0.457))))
+        ))
     );
-
     return fakes;
   }
 
   static Map<String, ListField> getSampleWichRender2LinesInsteadOfOne() {
     Map<String, ListField> fakes = new HashMap<>();
-
     fakes.put(
       "names",
       new ListField(
@@ -332,9 +416,9 @@ class FakeListField {
                         new Point(0.263, 0.42),
                         new Point(0.33, 0.42),
                         new Point(0.33, 0.428),
-                        new Point(0.263, 0.428))))))
+                        new Point(0.263, 0.428))))
+        ))
     );
-
     return fakes;
   }
 }

--- a/src/test/java/com/mindee/parsing/custom/lineitems/LineGeneratorTest.java
+++ b/src/test/java/com/mindee/parsing/custom/lineitems/LineGeneratorTest.java
@@ -1,62 +1,94 @@
 package com.mindee.parsing.custom.lineitems;
 
+import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
-
+import java.util.Collections;
+import java.util.List;
 import org.apache.commons.math3.util.Precision;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class LineGeneratorTest {
 
+  private static final List<Anchor> anchors = new ArrayList<>(
+      Collections.singletonList(new Anchor("names", 0.01d))
+  );
+
   @Test
   void prepareLinesWith2ValuesOnEachLineWithPolygonValuesOnExactlyTheSameAxis() {
-    Anchor anchor = new Anchor("names");
-
-    Collection<Line> table = LineGenerator.prepareLines(
+    Collection<Line> lines = LineGenerator.prepareLines(
       FakeListField.getWith2ValuesByExpectedLines(),
-      anchor
-    );
+      anchors
+    ).getLines();
+    Assertions.assertEquals(2, lines.size());
+  }
 
-    Assertions.assertEquals(2, table.size());
+  @Test
+  void prepareLinesWhenAnchorHasMoreLines() {
+    Collection<Line> lines = LineGenerator.prepareLines(
+      FakeListField.get2completeLines1halfLine(),
+      new ArrayList<>(
+        Collections.singletonList(new Anchor("birthDates"))
+      )
+    ).getLines();
+    Assertions.assertEquals(3, lines.size());
+  }
+
+  @Test
+  void prepareLinesWithTwoAnchors() {
+    PreparedLines preparedLines = LineGenerator.prepareLines(
+      FakeListField.get2completeLines1halfLine(),
+      new ArrayList<>(
+        Arrays.asList(
+          new Anchor("names"),
+          new Anchor("birthDates")
+        )
+      )
+    );
+    Assertions.assertEquals("birthDates", preparedLines.getAnchor().getName());
+    Assertions.assertEquals(3, preparedLines.getLines().size());
   }
 
   @Test
   void prepareLinesWith1FieldValueForTheLastLine() {
-    Anchor anchor = new Anchor("names");
-
-    Collection<Line> table = LineGenerator.prepareLines(
-        FakeListField.getWith1FieldValueForTheLastLine(), anchor);
-
-    Assertions.assertEquals(3, table.size());
+    Collection<Line> lines = LineGenerator.prepareLines(
+        FakeListField.getWith1FieldValueForTheLastLine(),
+        anchors
+    ).getLines();
+    Assertions.assertEquals(3, lines.size());
   }
 
   @Test
   void prepareLinesWith1ExpectedLine() {
-    Anchor anchor = new Anchor("names");
-
     Collection<Line> table = LineGenerator.prepareLines(
-        FakeListField.getWith1ExpectedLines(), anchor);
-
+        FakeListField.getWith1ExpectedLines(),
+        anchors
+    ).getLines();
     Assertions.assertEquals(1, table.size());
   }
 
   @Test
   void prepareLinesWithPolygonsNotExactlyOnTheSameAxis() {
-    Anchor anchor = new Anchor("names", 0.005d);
-
+    List<Anchor> anchors = new ArrayList<>(
+      Collections.singletonList(new Anchor("names", 0.005d))
+    );
     Collection<Line> table = LineGenerator.prepareLines(
-        FakeListField.getWithPolygonsNotExactlyOnTheSameAxis(), anchor);
-
+        FakeListField.getWithPolygonsNotExactlyOnTheSameAxis(),
+        anchors
+    ).getLines();
     Assertions.assertEquals(2, table.size());
   }
 
   @Test
   void prepareLinesWhichRender2LinesInsteadOfOne() {
-    Anchor anchor = new Anchor("names", 0.0d);
-
+    List<Anchor> anchors = new ArrayList<>(
+      Collections.singletonList(new Anchor("names", 0.0d))
+    );
     Collection<Line> table = LineGenerator.prepareLines(
-        FakeListField.getSampleWichRender2LinesInsteadOfOne(), anchor);
-
+        FakeListField.getSampleWichRender2LinesInsteadOfOne(),
+        anchors
+    ).getLines();
     Assertions.assertEquals(1, table.size());
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Allow passing multiple anchors for line reconstruction. Choose the one with the most lines.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
