### PR TITLE
:sparkles: allow comparing v2 field confidence

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -29,7 +29,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.distribution }}

--- a/.github/workflows/_publish-docs.yml
+++ b/.github/workflows/_publish-docs.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "11"
           distribution: "temurin"
@@ -45,7 +45,6 @@ jobs:
             echo "Documentation not generated properly"
             exit 1
           fi
-
 
       - name: Copy Code Samples
         run: |

--- a/.github/workflows/_test-integrations.yml
+++ b/.github/workflows/_test-integrations.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.distribution }}

--- a/src/main/java/com/mindee/parsing/v2/field/FieldConfidence.java
+++ b/src/main/java/com/mindee/parsing/v2/field/FieldConfidence.java
@@ -7,10 +7,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Confidence level of a field as returned by the V2 API.
  */
 public enum FieldConfidence {
-  Certain("Certain"),
-  High("High"),
+  Low("Low"),
   Medium("Medium"),
-  Low("Low");
+  High("High"),
+  Certain("Certain");
 
   private final String json;
 
@@ -34,5 +34,53 @@ public enum FieldConfidence {
       }
     }
     throw new IllegalArgumentException("Unknown confidence level '" + value + "'.");
+  }
+
+  /**
+   * Compares the current FieldConfidence level with another FieldConfidence level
+   * to determine if the current level is greater.
+   *
+   * @param other the other FieldConfidence level to compare against
+   * @return true if the current FieldConfidence level is greater than the specified level,
+   *         false otherwise
+   */
+  public boolean greaterThan(FieldConfidence other) {
+    return this.compareTo(other) > 0;
+  }
+
+  /**
+   * Compares the current FieldConfidence level with another FieldConfidence level
+   * to determine if the current level is greater than or equal to the specified level.
+   *
+   * @param other the other FieldConfidence level to compare against
+   * @return true if the current FieldConfidence level is greater than or equal to the specified level,
+   *         false otherwise
+   */
+  public boolean greaterThanOrEqual(FieldConfidence other) {
+    return this.compareTo(other) >= 0;
+  }
+
+  /**
+   * Compares the current FieldConfidence level with another FieldConfidence level
+   * to determine if the current level is less than the specified level.
+   *
+   * @param other the other FieldConfidence level to compare against
+   * @return true if the current FieldConfidence level is less than the specified level,
+   *         false otherwise
+   */
+  public boolean lessThan(FieldConfidence other) {
+    return this.compareTo(other) < 0;
+  }
+
+  /**
+   * Compares the current FieldConfidence level with another FieldConfidence level
+   * to determine if the current level is less than or equal to the specified level.
+   *
+   * @param other the other FieldConfidence level to compare against
+   * @return true if the current FieldConfidence level is less than or equal to the specified level,
+   *         false otherwise
+   */
+  public boolean lessThanOrEqual(FieldConfidence other) {
+    return this.compareTo(other) <= 0;
   }
 }

--- a/src/test/java/com/mindee/parsing/v2/InferenceTest.java
+++ b/src/test/java/com/mindee/parsing/v2/InferenceTest.java
@@ -426,6 +426,11 @@ class InferenceTest {
     FieldConfidence confidence = fieldSimpleString.getConfidence();
     boolean isCertain = confidence == FieldConfidence.Certain;
     assertTrue(isCertain);
+    assertEquals(3, confidence.ordinal());
+    assertTrue(confidence.greaterThanOrEqual(FieldConfidence.Certain));
+    assertTrue(confidence.greaterThan(FieldConfidence.Medium));
+    assertTrue(confidence.lessThanOrEqual(FieldConfidence.Certain));
+    assertFalse(confidence.lessThan(FieldConfidence.Certain));
 
     List<FieldLocation> locations = fieldSimpleString.getLocations();
     assertEquals(1, locations.size());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Make sure we can compare confidence enums.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
