### PR TITLE
:bug: base64 input should not be strict

### DIFF
--- a/src/main/java/com/mindee/input/LocalInputSource.java
+++ b/src/main/java/com/mindee/input/LocalInputSource.java
@@ -55,7 +55,7 @@ public class LocalInputSource {
   }
 
   public LocalInputSource(String fileAsBase64, String filename) {
-    this.file = Base64.getDecoder().decode(fileAsBase64.getBytes());
+    this.file = Base64.getMimeDecoder().decode(fileAsBase64.getBytes());
     this.filename = filename;
   }
 

--- a/src/test/java/com/mindee/input/LocalInputSourceTest.java
+++ b/src/test/java/com/mindee/input/LocalInputSourceTest.java
@@ -8,9 +8,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class LocalInputSourceTest {
   void assertMultipagePDF(LocalInputSource inputSource, Path filePath) throws IOException {
@@ -66,42 +69,59 @@ public class LocalInputSourceTest {
     Assertions.assertTrue(localInputSource.isPDF());
   }
 
-  void assertImage(LocalInputSource inputSource, Path filePath) throws IOException {
+  void assertImage(
+      LocalInputSource inputSource,
+      Path filePath,
+      String filename
+  ) throws IOException {
     Assertions.assertNotNull(inputSource);
 
     Assertions.assertFalse(inputSource.isPDF());
     Assertions.assertEquals(1, inputSource.getPageCount());
-    Assertions.assertEquals("receipt.jpg", inputSource.getFilename());
+    Assertions.assertEquals(filename, inputSource.getFilename());
     Assertions.assertArrayEquals(inputSource.getFile(), Files.readAllBytes(filePath));
   }
 
-  @Test
-  void loadImage_withFile_mustReturnAValidLocalInputSource() throws IOException {
-    File file = getResourcePath("file_types/receipt.jpg").toFile();
-    var localInputSource = new LocalInputSource(file);
-    assertImage(localInputSource, file.toPath());
+  private static Stream<String> imageExtensions() {
+    return Stream.of("heic", "heif", "jpg", "jpga", "png", "tif", "tiff", "webp");
   }
 
-  @Test
-  void loadImage_withInputStream_mustReturnAValidLocalInputSource() throws IOException {
-    Path filePath = getResourcePath("file_types/receipt.jpg");
-    var localInputSource = new LocalInputSource(Files.newInputStream(filePath), "receipt.jpg");
-    assertImage(localInputSource, filePath);
+  @ParameterizedTest
+  @MethodSource("imageExtensions")
+  void loadImage_withFile_mustReturnAValidLocalInputSource(String extension) throws IOException {
+    File file = getResourcePath("file_types/receipt." + extension).toFile();
+    var inputSource = new LocalInputSource(file);
+    assertImage(inputSource, file.toPath(), "receipt." + extension);
   }
 
-  @Test
-  void loadImage_withByteArray_mustReturnAValidLocalInputSource() throws IOException {
-    Path filePath = getResourcePath("file_types/receipt.jpg");
-    var localInputSource = new LocalInputSource(Files.readAllBytes(filePath), "receipt.jpg");
-    assertImage(localInputSource, filePath);
+  @ParameterizedTest
+  @MethodSource("imageExtensions")
+  void loadImage_withInputStream_mustReturnAValidLocalInputSource(
+      String extension
+  ) throws IOException {
+    Path filePath = getResourcePath("file_types/receipt." + extension);
+    var inputSource = new LocalInputSource(Files.newInputStream(filePath), "receipt." + extension);
+    assertImage(inputSource, filePath, "receipt." + extension);
+  }
+
+  @ParameterizedTest
+  @MethodSource("imageExtensions")
+  void loadImage_withByteArray_mustReturnAValidLocalInputSource(
+      String extension
+  ) throws IOException {
+    Path filePath = getResourcePath("file_types/receipt." + extension);
+    var inputSource = new LocalInputSource(Files.readAllBytes(filePath), "receipt." + extension);
+    assertImage(inputSource, filePath, "receipt." + extension);
   }
 
   @Test
   void loadImage_withBase64Encoded_mustReturnAValidLocalInputSource() throws IOException {
-    Path filePath = getResourcePath("file_types/receipt.jpg");
-    String encodedFile = Base64.encodeBase64String(Files.readAllBytes(filePath));
-    var localInputSource = new LocalInputSource(encodedFile, "receipt.jpg");
-    assertImage(localInputSource, filePath);
+    Path filePath = getResourcePath("file_types/receipt.txt");
+    String encodedFile = Files.readString(filePath, java.nio.charset.StandardCharsets.UTF_8);
+    var inputSource = new LocalInputSource(encodedFile, "receipt.jpg");
+    Assertions.assertFalse(inputSource.isPDF());
+    Assertions.assertEquals(1, inputSource.getPageCount());
+    Assertions.assertEquals("receipt.jpg", inputSource.getFilename());
   }
 
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

The `java.util.Base64.getDecoder()` (MIME-unaware) does not tolerate whitespace or line breaks, it throws IllegalArgumentException on any character outside the strict Base64 alphabet (like \n, \r, or trailing newlines).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
